### PR TITLE
Use coworker contact for notes; add schedule title

### DIFF
--- a/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/ScheduleMapper.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/ScheduleMapper.java
@@ -3,6 +3,7 @@ package com.solarize.solarizeWebBackend.modules.schedule;
 import com.solarize.solarizeWebBackend.modules.project.Project;
 import com.solarize.solarizeWebBackend.modules.schedule.dto.CreateScheduleDTO;
 import com.solarize.solarizeWebBackend.modules.schedule.dto.CreateScheduleRabbitDTO;
+import com.solarize.solarizeWebBackend.modules.schedule.dto.RecipientDTO;
 import com.solarize.solarizeWebBackend.modules.schedule.dto.ScheduleResponseDTO;
 
 import java.util.List;
@@ -64,28 +65,13 @@ public class ScheduleMapper {
         Project project = schedule.getProject();
         String projectName = (project != null) ? project.getName() : "N/A";
 
-
-        String email = null;
-        String phone = null;
-
-        if (schedule.getType() == ScheduleTypeEnum.NOTE) {
-            if (schedule.getCoworker() != null) {
-                email = schedule.getCoworker().getEmail();
-                phone = schedule.getCoworker().getPhone();
-            }
-        } else {
-            if (project != null && project.getClient() != null) {
-                email = project.getClient().getEmail();
-                phone = project.getClient().getPhone();
-            }
-        }
+        List<RecipientDTO> recipients = schedule.getType().recipientStrategy.resolve(schedule);
 
         return new CreateScheduleRabbitDTO(
                 schedule.getId(),
                 projectName,
                 schedule.getTitle(),
-                email,
-                phone,
+                recipients,
                 schedule.getType(),
                 schedule.getStartDate(),
                 schedule.getEndDate()

--- a/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/ScheduleMapper.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/ScheduleMapper.java
@@ -63,17 +63,33 @@ public class ScheduleMapper {
 
         Project project = schedule.getProject();
         String projectName = (project != null) ? project.getName() : "N/A";
-        String email = (project != null && project.getClient() != null) ? project.getClient().getEmail() : null;
-        String phone = (project != null && project.getClient() != null) ? project.getClient().getPhone() : null;
+
+
+        String email = null;
+        String phone = null;
+
+        if (schedule.getType() == ScheduleTypeEnum.NOTE) {
+            if (schedule.getCoworker() != null) {
+                email = schedule.getCoworker().getEmail();
+                phone = schedule.getCoworker().getPhone();
+            }
+        } else {
+            if (project != null && project.getClient() != null) {
+                email = project.getClient().getEmail();
+                phone = project.getClient().getPhone();
+            }
+        }
 
         return new CreateScheduleRabbitDTO(
                 schedule.getId(),
                 projectName,
+                schedule.getTitle(),
                 email,
                 phone,
                 schedule.getType(),
                 schedule.getStartDate(),
                 schedule.getEndDate()
         );
+
     }
 }

--- a/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/ScheduleTypeEnum.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/ScheduleTypeEnum.java
@@ -1,7 +1,17 @@
 package com.solarize.solarizeWebBackend.modules.schedule;
 
+import com.solarize.solarizeWebBackend.modules.schedule.strategy.NoteRecipientStrategy;
+import com.solarize.solarizeWebBackend.modules.schedule.strategy.NotificationRecipientStrategy;
+import com.solarize.solarizeWebBackend.modules.schedule.strategy.VisitRecipientStrategy;
+
 public enum ScheduleTypeEnum {
-    TECHNICAL_VISIT,
-    INSTALL_VISIT,
-    NOTE;
+    TECHNICAL_VISIT(new VisitRecipientStrategy()),
+    INSTALL_VISIT(new VisitRecipientStrategy()),
+    NOTE(new NoteRecipientStrategy());
+
+    public final NotificationRecipientStrategy recipientStrategy;
+
+    ScheduleTypeEnum(NotificationRecipientStrategy recipientStrategy) {
+        this.recipientStrategy = recipientStrategy;
+    }
 }

--- a/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/dto/CreateScheduleRabbitDTO.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/dto/CreateScheduleRabbitDTO.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 public record CreateScheduleRabbitDTO(
         Long scheduleId,
         String projectTitle,
+        String title,
         String email,
         String phone,
         ScheduleTypeEnum type,

--- a/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/dto/CreateScheduleRabbitDTO.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/dto/CreateScheduleRabbitDTO.java
@@ -3,13 +3,13 @@ package com.solarize.solarizeWebBackend.modules.schedule.dto;
 import com.solarize.solarizeWebBackend.modules.schedule.ScheduleTypeEnum;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record CreateScheduleRabbitDTO(
         Long scheduleId,
         String projectTitle,
         String title,
-        String email,
-        String phone,
+        List<RecipientDTO> recipients,
         ScheduleTypeEnum type,
         LocalDateTime startDate,
         LocalDateTime endDate

--- a/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/dto/RecipientDTO.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/dto/RecipientDTO.java
@@ -1,0 +1,6 @@
+package com.solarize.solarizeWebBackend.modules.schedule.dto;
+
+public record RecipientDTO(
+        String email,
+        String phone
+) {}

--- a/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/strategy/NoteRecipientStrategy.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/strategy/NoteRecipientStrategy.java
@@ -1,0 +1,27 @@
+package com.solarize.solarizeWebBackend.modules.schedule.strategy;
+
+import com.solarize.solarizeWebBackend.modules.schedule.Schedule;
+import com.solarize.solarizeWebBackend.modules.schedule.dto.RecipientDTO;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Component
+public class NoteRecipientStrategy implements NotificationRecipientStrategy {
+
+    @Override
+    public List<RecipientDTO> resolve(Schedule schedule){
+        List<RecipientDTO> recipients = new ArrayList<>();
+
+        if (schedule.getCoworker() != null){
+            recipients.add(new RecipientDTO(
+                    schedule.getCoworker().getEmail(),
+                    schedule.getCoworker().getPhone()
+            ));
+        }
+
+        return recipients;
+    }
+}

--- a/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/strategy/NotificationRecipientStrategy.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/strategy/NotificationRecipientStrategy.java
@@ -1,0 +1,10 @@
+package com.solarize.solarizeWebBackend.modules.schedule.strategy;
+
+import com.solarize.solarizeWebBackend.modules.schedule.Schedule;
+import com.solarize.solarizeWebBackend.modules.schedule.dto.RecipientDTO;
+
+import java.util.List;
+
+public interface NotificationRecipientStrategy {
+    List<RecipientDTO> resolve(Schedule schedule);
+}

--- a/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/strategy/VisitRecipientStrategy.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/schedule/strategy/VisitRecipientStrategy.java
@@ -1,0 +1,33 @@
+package com.solarize.solarizeWebBackend.modules.schedule.strategy;
+
+import com.solarize.solarizeWebBackend.modules.schedule.Schedule;
+import com.solarize.solarizeWebBackend.modules.schedule.dto.RecipientDTO;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class VisitRecipientStrategy implements NotificationRecipientStrategy {
+
+    @Override
+    public List<RecipientDTO> resolve(Schedule schedule) {
+        List<RecipientDTO> recipients = new ArrayList<>();
+
+        if (schedule.getCoworker() != null) {
+            recipients.add(new RecipientDTO(
+                    schedule.getCoworker().getEmail(),
+                    schedule.getCoworker().getPhone()
+            ));
+        }
+
+        if (schedule.getProject() != null && schedule.getProject().getClient() != null) {
+            recipients.add(new RecipientDTO(
+                    schedule.getProject().getClient().getEmail(),
+                    schedule.getProject().getClient().getPhone()
+            ));
+        }
+
+        return recipients;
+    }
+}


### PR DESCRIPTION
ScheduleMapper now selects email/phone from the coworker when the schedule type is NOTE; otherwise it falls back to the project's client. The CreateScheduleRabbitDTO was extended with a title field and schedule.getTitle() is passed into the DTO so the rabbit payload includes the schedule title.