### PR TITLE
Add automatic budget config and pre-budget adjust

### DIFF
--- a/src/main/java/com/solarize/solarizeWebBackend/modules/budget/AutomaticBudgetConfigController.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/budget/AutomaticBudgetConfigController.java
@@ -1,0 +1,37 @@
+package com.solarize.solarizeWebBackend.modules.budget;
+
+import com.solarize.solarizeWebBackend.modules.budget.dto.request.AutomaticBudgetConfigDto;
+import com.solarize.solarizeWebBackend.modules.budget.dto.response.AutomaticBudgetConfigResponseDto;
+import com.solarize.solarizeWebBackend.modules.budget.model.ConfigParameter;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/automatic-budget-config")
+@RequiredArgsConstructor
+public class AutomaticBudgetConfigController {
+
+    private final AutomaticBudgetConfigService automaticBudgetConfigService;
+
+    @PreAuthorize("hasAuthority('CONFIGURATION_READ')")
+    @GetMapping
+    public ResponseEntity<AutomaticBudgetConfigResponseDto> getConfig() {
+        AutomaticBudgetConfigResponseDto dto = automaticBudgetConfigService.getConfig();
+        return ResponseEntity.ok(dto);
+    }
+
+    @PreAuthorize("hasAuthority('CONFIGURATION_WRITE')")
+    @PutMapping
+    public ResponseEntity<AutomaticBudgetConfigResponseDto> saveConfig(
+            @RequestBody @Valid AutomaticBudgetConfigDto dto
+    ) {
+        List<ConfigParameter> toSave = AutomaticBudgetConfigMapper.toEntityList(dto);
+        AutomaticBudgetConfigResponseDto response = automaticBudgetConfigService.saveConfig(toSave);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/solarize/solarizeWebBackend/modules/budget/AutomaticBudgetConfigMapper.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/budget/AutomaticBudgetConfigMapper.java
@@ -1,0 +1,86 @@
+package com.solarize.solarizeWebBackend.modules.budget;
+
+import com.solarize.solarizeWebBackend.modules.budget.dto.request.AutomaticBudgetConfigDto;
+import com.solarize.solarizeWebBackend.modules.budget.dto.response.AutomaticBudgetConfigResponseDto;
+import com.solarize.solarizeWebBackend.modules.budget.enumerated.AutomaticBudgetConfigKey;
+import com.solarize.solarizeWebBackend.modules.budget.enumerated.ConfigValueType;
+import com.solarize.solarizeWebBackend.modules.budget.model.ConfigParameter;
+
+import java.util.List;
+
+public class AutomaticBudgetConfigMapper {
+
+    public static AutomaticBudgetConfigResponseDto toDto(
+            Double pricePerKwp,
+            Double energyTariff,
+            Double propertyTypeCasaTerrea,
+            Double propertyTypeSobrado,
+            Double propertyTypePredio,
+            Double roofTypeMetalico,
+            Double roofTypeCeramico,
+            Double roofTypeFibrocimento,
+            Double roofTypeLaje
+    ) {
+        return AutomaticBudgetConfigResponseDto.builder()
+                .pricePerKwp(pricePerKwp)
+                .energyTariff(energyTariff)
+                .propertyTypeCasaTerrea(propertyTypeCasaTerrea)
+                .propertyTypeSobrado(propertyTypeSobrado)
+                .propertyTypePredio(propertyTypePredio)
+                .roofTypeMetalico(roofTypeMetalico)
+                .roofTypeCeramico(roofTypeCeramico)
+                .roofTypeFibrocimento(roofTypeFibrocimento)
+                .roofTypeLaje(roofTypeLaje)
+                .build();
+    }
+
+    public static List<ConfigParameter> toEntityList(AutomaticBudgetConfigDto dto) {
+        return List.of(
+                ConfigParameter.builder()
+                        .uniqueName(AutomaticBudgetConfigKey.SOLAR_PRICE_PER_KWP.name())
+                        .parameterValue(dto.getPricePerKwp())
+                        .configValueType(ConfigValueType.AMOUNT)
+                        .build(),
+                ConfigParameter.builder()
+                        .uniqueName(AutomaticBudgetConfigKey.SOLAR_TARIFF.name())
+                        .parameterValue(dto.getEnergyTariff())
+                        .configValueType(ConfigValueType.AMOUNT)
+                        .build(),
+                ConfigParameter.builder()
+                        .uniqueName(AutomaticBudgetConfigKey.PROPERTY_TYPE_CASA_TERREA.name())
+                        .parameterValue(dto.getPropertyTypeCasaTerrea())
+                        .configValueType(ConfigValueType.PERCENT)
+                        .build(),
+                ConfigParameter.builder()
+                        .uniqueName(AutomaticBudgetConfigKey.PROPERTY_TYPE_SOBRADO.name())
+                        .parameterValue(dto.getPropertyTypeSobrado())
+                        .configValueType(ConfigValueType.PERCENT)
+                        .build(),
+                ConfigParameter.builder()
+                        .uniqueName(AutomaticBudgetConfigKey.PROPERTY_TYPE_PREDIO.name())
+                        .parameterValue(dto.getPropertyTypePredio())
+                        .configValueType(ConfigValueType.PERCENT)
+                        .build(),
+                ConfigParameter.builder()
+                        .uniqueName(AutomaticBudgetConfigKey.ROOF_TYPE_METALICO.name())
+                        .parameterValue(dto.getRoofTypeMetalico())
+                        .configValueType(ConfigValueType.PERCENT)
+                        .build(),
+                ConfigParameter.builder()
+                        .uniqueName(AutomaticBudgetConfigKey.ROOF_TYPE_CERAMICO.name())
+                        .parameterValue(dto.getRoofTypeCeramico())
+                        .configValueType(ConfigValueType.PERCENT)
+                        .build(),
+                ConfigParameter.builder()
+                        .uniqueName(AutomaticBudgetConfigKey.ROOF_TYPE_FIBROCIMENTO.name())
+                        .parameterValue(dto.getRoofTypeFibrocimento())
+                        .configValueType(ConfigValueType.PERCENT)
+                        .build(),
+                ConfigParameter.builder()
+                        .uniqueName(AutomaticBudgetConfigKey.ROOF_TYPE_LAJE.name())
+                        .parameterValue(dto.getRoofTypeLaje())
+                        .configValueType(ConfigValueType.PERCENT)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/com/solarize/solarizeWebBackend/modules/budget/AutomaticBudgetConfigService.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/budget/AutomaticBudgetConfigService.java
@@ -1,0 +1,54 @@
+package com.solarize.solarizeWebBackend.modules.budget;
+
+import com.solarize.solarizeWebBackend.modules.budget.dto.response.AutomaticBudgetConfigResponseDto;
+import com.solarize.solarizeWebBackend.modules.budget.enumerated.AutomaticBudgetConfigKey;
+import com.solarize.solarizeWebBackend.modules.budget.model.ConfigParameter;
+import com.solarize.solarizeWebBackend.modules.budget.repository.ConfigParameterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AutomaticBudgetConfigService {
+
+    private final ConfigParameterRepository configParameterRepository;
+
+    public AutomaticBudgetConfigResponseDto getConfig() {
+        return AutomaticBudgetConfigMapper.toDto(
+                getValue(AutomaticBudgetConfigKey.SOLAR_PRICE_PER_KWP, 4500.0),
+                getValue(AutomaticBudgetConfigKey.SOLAR_TARIFF, 0.90),
+                getValue(AutomaticBudgetConfigKey.PROPERTY_TYPE_CASA_TERREA, 0.0),
+                getValue(AutomaticBudgetConfigKey.PROPERTY_TYPE_SOBRADO, 0.0),
+                getValue(AutomaticBudgetConfigKey.PROPERTY_TYPE_PREDIO, 0.0),
+                getValue(AutomaticBudgetConfigKey.ROOF_TYPE_METALICO, 0.0),
+                getValue(AutomaticBudgetConfigKey.ROOF_TYPE_CERAMICO, 0.0),
+                getValue(AutomaticBudgetConfigKey.ROOF_TYPE_FIBROCIMENTO, 0.0),
+                getValue(AutomaticBudgetConfigKey.ROOF_TYPE_LAJE, 0.0)
+        );
+    }
+
+    public AutomaticBudgetConfigResponseDto saveConfig(List<ConfigParameter> toSave) {
+        toSave.stream().map(param -> {
+            ConfigParameter existing = configParameterRepository
+                    .findByUniqueName(param.getUniqueName())
+                    .orElse(ConfigParameter.builder()
+                            .uniqueName(param.getUniqueName())
+                            .configValueType(param.getConfigValueType())
+                            .build());
+
+            existing.setParameterValue(param.getParameterValue());
+            return configParameterRepository.save(existing);
+        }).toList();
+
+        return getConfig();
+    }
+
+    private Double getValue(AutomaticBudgetConfigKey key, Double defaultValue) {
+        return configParameterRepository
+                .findByUniqueName(key.name())
+                .map(ConfigParameter::getParameterValue)
+                .orElse(defaultValue);
+    }
+}

--- a/src/main/java/com/solarize/solarizeWebBackend/modules/budget/BudgetService.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/budget/BudgetService.java
@@ -455,7 +455,7 @@ public class BudgetService {
         return budgetRepository.save(budget);
     }
 
-    public Map<String, Double> calculatePreBudget(Project project, Double monthlyBill) {
+    public Map<String, Double> calculatePreBudget(Project project, Double monthlyBill, String propertyType, String roofType) {
         List<ConfigParameter> parameters = configParameterRepository.findAll();
 
         Double tariff = Objects.requireNonNull(parameters.stream()
@@ -483,6 +483,18 @@ public class BudgetService {
                         .orElse(null))
                 .getParameterValue();
 
+        Double propertyAdjust = parameters.stream()
+                .filter(p -> p.getUniqueName().equals(propertyType))
+                .findFirst()
+                .map(ConfigParameter::getParameterValue)
+                .orElse(0.0);
+
+        Double roofAdjust = parameters.stream()
+                .filter(p -> p.getUniqueName().equals(roofType))
+                .findFirst()
+                .map(ConfigParameter::getParameterValue)
+                .orElse(0.0);
+
         Map<String, Double> results = BudgetCalcs.preBudgetCalc(
                 monthlyBill,
                 tariff,
@@ -491,6 +503,11 @@ public class BudgetService {
                 pricePerKwp
         );
 
+        Double baseCost = results.get("cost");
+        Double totalAdjustPercent = (propertyAdjust + roofAdjust) / 100.0;
+        Double adjustedCost = baseCost * (1 + totalAdjustPercent);
+        results.put("cost", adjustedCost);
+
         Budget preBudget = new Budget();
         preBudget.setProject(project);
         preBudget.setFinalBudget(false);
@@ -498,7 +515,7 @@ public class BudgetService {
         PersonalizedParameter preBudgetParam = PersonalizedParameter.builder()
                 .name("Pré-orçamento")
                 .type(ParameterValueType.AMOUNT)
-                .parameterValue(results.get("cost"))
+                .parameterValue(adjustedCost)
                 .budget(preBudget)
                 .build();
                 

--- a/src/main/java/com/solarize/solarizeWebBackend/modules/budget/dto/request/AutomaticBudgetConfigDto.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/budget/dto/request/AutomaticBudgetConfigDto.java
@@ -1,0 +1,47 @@
+package com.solarize.solarizeWebBackend.modules.budget.dto.request;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AutomaticBudgetConfigDto {
+
+    @NotNull
+    @DecimalMin(value = "0.0", message = "Price per kWp cannot be negative.")
+    private Double pricePerKwp;
+
+    @NotNull
+    @DecimalMin(value = "0.0", message = "Energy tariff cannot be negative.")
+    private Double energyTariff;
+
+    @NotNull
+    @DecimalMin(value = "0.0", message = "Value cannot be negative.")
+    private Double propertyTypeCasaTerrea;
+
+    @NotNull
+    @DecimalMin(value = "0.0", message = "Value cannot be negative.")
+    private Double propertyTypeSobrado;
+
+    @NotNull
+    @DecimalMin(value = "0.0", message = "Value cannot be negative.")
+    private Double propertyTypePredio;
+
+    @NotNull
+    @DecimalMin(value = "0.0", message = "Value cannot be negative.")
+    private Double roofTypeMetalico;
+
+    @NotNull
+    @DecimalMin(value = "0.0", message = "Value cannot be negative.")
+    private Double roofTypeCeramico;
+
+    @NotNull
+    @DecimalMin(value = "0.0", message = "Value cannot be negative.")
+    private Double roofTypeFibrocimento;
+
+    @NotNull
+    @DecimalMin(value = "0.0", message = "Value cannot be negative.")
+    private Double roofTypeLaje;
+}

--- a/src/main/java/com/solarize/solarizeWebBackend/modules/budget/dto/response/AutomaticBudgetConfigResponseDto.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/budget/dto/response/AutomaticBudgetConfigResponseDto.java
@@ -1,0 +1,20 @@
+package com.solarize.solarizeWebBackend.modules.budget.dto.response;
+
+import lombok.*;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AutomaticBudgetConfigResponseDto {
+    private Double pricePerKwp;
+    private Double energyTariff;
+    private Double propertyTypeCasaTerrea;
+    private Double propertyTypeSobrado;
+    private Double propertyTypePredio;
+    private Double roofTypeMetalico;
+    private Double roofTypeCeramico;
+    private Double roofTypeFibrocimento;
+    private Double roofTypeLaje;
+}

--- a/src/main/java/com/solarize/solarizeWebBackend/modules/budget/enumerated/AutomaticBudgetConfigKey.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/budget/enumerated/AutomaticBudgetConfigKey.java
@@ -1,0 +1,13 @@
+package com.solarize.solarizeWebBackend.modules.budget.enumerated;
+
+public enum AutomaticBudgetConfigKey {
+    SOLAR_PRICE_PER_KWP,
+    SOLAR_TARIFF,
+    PROPERTY_TYPE_CASA_TERREA,
+    PROPERTY_TYPE_SOBRADO,
+    PROPERTY_TYPE_PREDIO,
+    ROOF_TYPE_METALICO,
+    ROOF_TYPE_CERAMICO,
+    ROOF_TYPE_FIBROCIMENTO,
+    ROOF_TYPE_LAJE;
+}

--- a/src/main/java/com/solarize/solarizeWebBackend/modules/project/ProjectService.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/project/ProjectService.java
@@ -349,7 +349,7 @@ public class ProjectService {
         
         Double monthlyBillValue = Double.parseDouble(dto.getMonthlyBill());
 
-        return budgetService.calculatePreBudget(savedProject, monthlyBillValue);
+        return budgetService.calculatePreBudget(savedProject, monthlyBillValue, dto.getPropertyType(), dto.getRoofType());
     }
 
     @Transactional
@@ -373,7 +373,7 @@ public class ProjectService {
 
         Double monthlyBillValue = Double.parseDouble(dto.getMonthlyBill());
 
-        return budgetService.calculatePreBudget(savedProject, monthlyBillValue);
+        return budgetService.calculatePreBudget(savedProject, monthlyBillValue, dto.getPropertyType(), dto.getRoofType());
     }
 
     public ProjectKpiDto getProjectKpis() {

--- a/src/main/java/com/solarize/solarizeWebBackend/modules/project/dto/request/ProjectBotLeadCreateDto.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/project/dto/request/ProjectBotLeadCreateDto.java
@@ -18,6 +18,7 @@ public class ProjectBotLeadCreateDto {
     
     private String cityState;
     private String propertyType;
+    private String roofType;
     
     @Valid
     private CreateAddressDto address;

--- a/src/main/java/com/solarize/solarizeWebBackend/modules/project/dto/request/ProjectSiteLeadCreateDto.java
+++ b/src/main/java/com/solarize/solarizeWebBackend/modules/project/dto/request/ProjectSiteLeadCreateDto.java
@@ -21,6 +21,7 @@ public class ProjectSiteLeadCreateDto {
     
     private String cityState;
     private String propertyType;
+    private String roofType;
     
     @Valid
     private CreateAddressDto address;


### PR DESCRIPTION
Introduce automatic budget configuration endpoints and DTOs (controller, service, mapper, request/response DTOs, and enum) to manage price/tariff and property/roof adjustments stored in ConfigParameter. Integrate these configs into BudgetService: calculatePreBudget now accepts propertyType and roofType, applies their percent adjustments to the base cost, and persists the adjusted pre-budget parameter. Update ProjectService and lead DTOs to pass roofType through pre-budget flows. Includes input validation and sensible defaults when config entries are missing.